### PR TITLE
change type of apiToken from "" to string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module "entsoe-api-node" {
   export default function (options?: {
-    apiToken: "";
+    apiToken: string;
     testnet?: boolean;
   }): Entsoe;
 


### PR DESCRIPTION
This will prevent typescript from throwing an error  Type 'string' is not assignable to type '""'