### PR TITLE
Add request throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Time is always expressed in UTC.
 
 Each method accepts an optional second parameter to customize the XML response.
 
+Automatically throttle if the limit of 400 requests per minute is reached.
+
 ```js
 console.log(await client.dayAheadPrices({ biddingZone: "10Y1001A1001A47J" }, (xmlString) async => /* parse the XML and return some magic */));
 ```

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,4 +14,5 @@ module.exports = {
       statements: thresholdPercentage,
     },
   },
+  resetMocks: true,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "entsoe-api-node",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "entsoe-api-node",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "2.6.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "entsoe-api-node",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Unofficial API wrapper for the ENTSO-E Transparency Platform API (https://transparency.entsoe.eu)",
   "author": "Robin Hansson <holla@rabinage.dev> (https://github.com/rabinage)",
   "repository": {


### PR DESCRIPTION
**Automatic Request Throttling**
To ensure stability and compliance with rate limits, this wrapper now includes automatic request throttling functionality. When making consecutive requests to the [ENTSO-E Transparency Platform](https://transparency.entsoe.eu/), the wrapper will monitor the request rate and automatically throttle if the limit of 400 requests per minute is reached.

This feature helps prevent exceeding the rate limit set by the platform, ensuring continuous access to the API without violating usage policies.